### PR TITLE
z-index modified so we let info bubble on top

### DIFF
--- a/lib/ExecutionControlEpic/ControlPanelFeature/Presenters/ControlPanel.js
+++ b/lib/ExecutionControlEpic/ControlPanelFeature/Presenters/ControlPanel.js
@@ -24,7 +24,7 @@ import CheckboxButton from "./CheckboxButton";
 import type { ConsoleSourcesReducer } from "../../ConsoleFeature/Reducers/ConsoleSources";
 
 const ControlPanelBox = styled.div`
-  z-index: 12;
+  z-index: 3;
   padding: 0px;
   margin: 0px;
   width: ${props => (props.isActive ? "300px" : "0px")};


### PR DESCRIPTION
We can see the panel be on top of the info bubble:
![ztomodified](https://user-images.githubusercontent.com/9026408/49471155-7b7ebe80-f80c-11e8-9a84-adbc03b766ce.png)

A z-index of 3 seems to be more than enough:
![zmodified](https://user-images.githubusercontent.com/9026408/49471218-a49f4f00-f80c-11e8-8794-b7dfbaa37e12.png)
