### PR TITLE
Filter some atom env variables from terminals

### DIFF
--- a/lib/ExecutionControlEpic/TerminalFeature/Epics/Terminals.js
+++ b/lib/ExecutionControlEpic/TerminalFeature/Epics/Terminals.js
@@ -2,6 +2,7 @@
 // @flow
 
 import Rx from "rxjs";
+import { filterAtomEnv } from "../Model/utils";
 import { addTerminal } from "../Actions/AddTerminal";
 import { removeTerminal } from "../Actions/RemoveTerminal";
 import TerminalStrategy from "../../LanguageServerProtocolFeature/Model/TerminalStrategy";
@@ -28,6 +29,7 @@ export function CreateTerminal() {
         let cwd = fs.lstatSync(action.payload.path).isFile()
           ? path.dirname(action.payload.path)
           : action.payload.path;
+        const env = filterAtomEnv(process.env);
 
         const strategy = new TerminalStrategy({
           strategy: {
@@ -35,7 +37,7 @@ export function CreateTerminal() {
             shell: shell,
             command: command,
             cwd: cwd,
-            env: process.env,
+            env,
           },
         });
 

--- a/lib/ExecutionControlEpic/TerminalFeature/Model/utils.js
+++ b/lib/ExecutionControlEpic/TerminalFeature/Model/utils.js
@@ -1,0 +1,11 @@
+"use babel";
+// @flow
+
+export function filterAtomEnv(env: Object) {
+  const filteredVars = ["ATOM_HOME", "NODE_PATH"];
+
+  return Object.entries(env).reduce((newEnv, [key, value]) => {
+    if (filteredVars.find(v => v === key) != null) return newEnv;
+    return { ...newEnv, [key]: value };
+  }, {});
+}

--- a/lib/ExecutionControlEpic/TerminalFeature/Model/utils.test.js
+++ b/lib/ExecutionControlEpic/TerminalFeature/Model/utils.test.js
@@ -1,0 +1,37 @@
+import { filterAtomEnv } from "./utils";
+
+describe("filterAtomEnv", () => {
+  const testEnv = {
+    COLORTERM: "truecolor",
+    DESKTOP_SESSION: "budgie-desktop",
+    DISPLAY: ":0",
+    GDMSESSION: "budgie-desktop",
+    HOME: "/home/tamer",
+    LANG: "en_US.utf8",
+    LC_CTYPE: "en_US.utf8",
+    OLDPWD: "/home/tamer/molecule",
+    PATH: "/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin:/snap/bin",
+    PWD: "/home/tamer/molecule",
+    SHELL: "/bin/zsh",
+    TERM: "xterm-256color",
+    USER: "tamer",
+    XAUTHORITY: "/home/tamer/.Xauthority",
+    ZSH: "/home/tamer/.oh-my-zsh",
+  };
+
+  it("should filter atom env vars", () => {
+    let subject = filterAtomEnv({
+      ...testEnv,
+      ATOM_HOME: "/home/tamer/.atom",
+      NODE_PATH: "/usr/share/atom/resources/app.asar/exports",
+    });
+
+    expect(subject).toEqual(testEnv);
+  });
+
+  it("should return env as is", () => {
+    let subject = filterAtomEnv(testEnv);
+
+    expect(subject).toEqual(testEnv);
+  });
+});


### PR DESCRIPTION
Right now the only two I've seen that are not supposed to be here: `ATOM_HOME` & `NODE_PATH`